### PR TITLE
Zip modules support

### DIFF
--- a/Dockerfile_nginx-56
+++ b/Dockerfile_nginx-56
@@ -42,6 +42,7 @@ RUN set -ex; \
       supervisor \
       tar \
       tzdata \
+      unzip \
     ; \
     apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,9 @@ function installPlugin() {
     *.tar.bz2)
       tar ${tar_options} -xj -f "${plugin_tmp_file}"
       ;;
+    *.zip)
+      unzip "${plugin_tmp_file}" -d "${GLPI_PATHS_PLUGINS}"
+      ;;
     *)
       echo "..#ERROR# unknown extension for ${file}. Please open an issue or make a PR to https://github.com/Turgon37/docker-glpi" 1>&2
       false

--- a/tests.sh
+++ b/tests.sh
@@ -106,3 +106,15 @@ if ! curl -v http://localhost:8000 2>&1 | grep --quiet 'install/install.php'; th
   false
 fi
 stop_and_remove_container "${image_name}"
+
+#6 Test plugins installation with zip
+echo '-> 6 Test plugins installation with zip'
+image_name=glpi_6
+docker run $docker_run_options --name "${image_name}" --env='GLPI_INSTALL_PLUGINS=timezones|https://github.com/tomolimo/timezones/releases/download/2.4.1/timezones-2.4.1.zip' "${image_building_name}"
+wait_for_string_in_container_logs "${image_name}" 'Starting up...'
+# test
+if ! docker exec "${image_name}" test -d plugins/fusioninventory; then
+  docker logs "${image_name}"
+  false
+fi
+stop_and_remove_container "${image_name}"


### PR DESCRIPTION
Some plugins (for example https://github.com/tomolimo/timezones/releases) packed in zip archive, so it's good to have support of zipped modules.

Tested and works well on 'timezones' module.